### PR TITLE
Ability to run accept_license.py on Windows 10 

### DIFF
--- a/modules/aviatrix_controller_azure/accept_license.py
+++ b/modules/aviatrix_controller_azure/accept_license.py
@@ -15,6 +15,7 @@ def accept_license():
             "aviatrix-systems:aviatrix-bundle-payg:aviatrix-enterprise-bundle-byol:latest",
         ],
         stdout=subprocess.PIPE,
+        shell=True,
     )
 
 
@@ -31,6 +32,7 @@ def get_license_details():
             "aviatrix-systems:aviatrix-bundle-payg:aviatrix-enterprise-bundle-byol:latest",
         ],
         stdout=subprocess.PIPE,
+        shell=True,
     )
     out = process.communicate()[0]
     py_dict = json.loads(out)


### PR DESCRIPTION
Hi Aviatrix,

These edits were required to get the accept_license.py script to run on my Windows device.
Setting the shell argument to a true value causes subprocess to spawn an intermediate shell process, and tell it to run the command.

Before the change, the script failed with the error as can be seen on this gallery: [https://imgur.com/a/DvFmCTw](https://imgur.com/a/DvFmCTw)
However, I am unsure whether the new subprocess still fails or the subprocess is unable to target the `az` command even though Azure CLI is installed on my machine.