### PR TITLE
Add output in build for subnet; main outputs added for vnet, rg, subnet

### DIFF
--- a/modules/aviatrix_controller_build/outputs.tf
+++ b/modules/aviatrix_controller_build/outputs.tf
@@ -25,3 +25,7 @@ output "aviatrix_controller_rg" {
 output "aviatrix_controller_subnet" {
   value = azurerm_subnet.aviatrix_controller_subnet
 }
+
+output "aviatrix_controller_name" {
+  value = azurerm_linux_virtual_machine.aviatrix_controller_vm.name
+}

--- a/modules/aviatrix_controller_build/outputs.tf
+++ b/modules/aviatrix_controller_build/outputs.tf
@@ -21,3 +21,7 @@ output "aviatrix_controller_vnet" {
 output "aviatrix_controller_rg" {
   value = azurerm_resource_group.aviatrix_controller_rg
 }
+
+output "aviatrix_controller_subnet" {
+  value = azurerm_subnet.aviatrix_controller_subnet
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,15 @@ output "avx_controller_public_ip" {
 output "avx_controller_private_ip" {
   value = module.aviatrix_controller_build.aviatrix_controller_private_ip_address
 }
+
+output "avx_controller_vnet" {
+  value = module.aviatrix_controller_build.aviatrix_controller_vnet
+}
+
+output "avx_controller_rg" {
+  value = module.aviatrix_controller_build.aviatrix_controller_rg
+}
+
+output "avx_controller_subnet" {
+  value = module.aviatrix_controller_build.aviatrix_controller_subnet
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,7 @@ output "avx_controller_rg" {
 output "avx_controller_subnet" {
   value = module.aviatrix_controller_build.aviatrix_controller_subnet
 }
+
+output "avx_controller_name" {
+  value = module.aviatrix_controller_build.aviatrix_controller_name
+}


### PR DESCRIPTION
In order to read some additional object/outputs from the build module:
- added subnet as an object output in build module

in main module output:
- added vnet, rg and subnet